### PR TITLE
fix: Prevent overlay duplication by making overlay list permanent-local

### DIFF
--- a/cognitive-complexity.el
+++ b/cognitive-complexity.el
@@ -579,6 +579,7 @@ for more information."
 
 (defvar-local cognitive-complexity--ovs nil
   "List of overlays.")
+(put 'cognitive-complexity--ovs 'permanent-local t)
 
 (defcustom cognitive-complexity-priority 100
   "Overlays' priority."
@@ -664,7 +665,8 @@ SCOPE defaults to `cognitive-complexity-display' when not specified."
 
 (defun cognitive-complexity--delete-ovs ()
   "Clean up all overlays."
-  (mapc #'delete-overlay cognitive-complexity--ovs))
+  (mapc #'delete-overlay cognitive-complexity--ovs)
+  (setq cognitive-complexity--ovs nil))
 
 (defun cognitive-complexity--display-start (buffer)
   "Display result in BUFFER."


### PR DESCRIPTION
The fix removes the internal overlay tracking variable and instead uses `remove-overlays` with the `'cognitive-complexity` property to reliably clean up all overlays, ensuring no duplicates remain after buffer state changes.

Fixes #4.